### PR TITLE
Fix bug in hypercuboid search

### DIFF
--- a/public/js/hcuboid.js
+++ b/public/js/hcuboid.js
@@ -204,7 +204,7 @@ function testPresent(state, p, hc) {
             result[nonPassL] = Object.keys(hc[nonPassL]).filter(ix => ix != "pass");
         }
         // Only remove points where there isn't an active branch further back
-        for (let l = newL; sgn * l < Math.abs(minL) + TSp; l += sgn * TSp) {
+        for (let l = newL; sgn * l <= Math.abs(minL) + TSp; l += sgn * TSp) {
             if (!(l in hc))
                 break;
             if (!(l in result))


### PR DESCRIPTION
CrazyPenguin found a case where it incorrectly claimed checkmate.

Here's PGN of the game that triggers it.

```
[Mode "5D"]
[Size "8x8"]
[Board "Standard"]
1.(0T1)Pe2(0T1)e3 / (0T1)Ng8(0T1)f6 
2.(0T2)Pb2(0T2)b4 / (0T2)Pd7(0T2)d5 
3.(0T3)Bc1(0T3)b2 / (0T3)Pc7(0T3)c6 
4.(0T4)Bb2(0T4)f6 / (0T4)Pg7(0T4)f6 
5.(0T5)Qd1(0T5)h5 / (0T5)Qd8(0T5)b6 
6.(0T6)Qh5>>(0T4)f7 / (1T4)Ke8(1T4)f7 
7.(1T5)Bb2(1T5)f6 / (1T5)Pg7(1T5)f6 
8.(1T6)Qd1(1T6)h5 / (0T6)Qb6>>(0T1)b6 
9.(-1T2)Pb2(-1T2)b3 / (-1T2)Ng8(-1T2)f6 
10.(-1T3)Bc1(-1T3)b2 / (-1T3)Pe7(-1T3)e6 
11.(-1T4)Bf1(-1T4)c4 / (-1T4)Qb6(-1T4)c6 
12.(-1T5)Bc4(-1T5)e6 / (-1T5)Pf7(-1T5)e6 
13.(-1T6)Bb2(-1T6)f6
```